### PR TITLE
Move votes, bloom, and quorumVerdicts to separate mappings.

### DIFF
--- a/contracts/BountyRegistry.sol
+++ b/contracts/BountyRegistry.sol
@@ -428,7 +428,7 @@ contract BountyRegistry is Pausable {
                 quorumVerdicts[i] = quorumVerdicts[i].add(1);
             }
 
-            // malVotes = quorumVerdicts
+            // malVotes = quorumVerdicts[i]
             uint256 benignVotes = bountyVerdicts.length.sub(quorumVerdicts[i]);
             uint256 maxBenignValue = arbiterCount.sub(quorumVerdicts[i]).mul(BENIGN_VOTE_COEFFICIENT);
             uint256 maxMalValue = arbiterCount.sub(benignVotes).mul(MALICIOUS_VOTE_COEFFICIENT);

--- a/contracts/BountyRegistry.sol
+++ b/contracts/BountyRegistry.sol
@@ -428,7 +428,6 @@ contract BountyRegistry is Pausable {
                 quorumVerdicts[i] = quorumVerdicts[i].add(1);
             }
 
-            // malVotes = quorumVerdicts[i]
             uint256 benignVotes = bountyVerdicts.length.sub(quorumVerdicts[i]);
             uint256 maxBenignValue = arbiterCount.sub(quorumVerdicts[i]).mul(BENIGN_VOTE_COEFFICIENT);
             uint256 maxMalValue = arbiterCount.sub(benignVotes).mul(MALICIOUS_VOTE_COEFFICIENT);


### PR DESCRIPTION
Our contract abi didn't have the votes, voters, bloom, bloomVotes, and quorumVerdicts included in the output of bountiesByGuid. 

This separates all those fields out into separate mappings that can be called separately.

Still requires modifications to 
- [x] polyswarmd
- [x] polyswarm-client

Fixes #51 
Fixes #5 